### PR TITLE
Allow nestjs/swagger ver 6+

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nanogiants/nestjs-swagger-api-exception-decorator",
-  "version": "1.6.1",
+  "version": "1.6.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nanogiants/nestjs-swagger-api-exception-decorator",
-      "version": "1.6.1",
+      "version": "1.6.4",
       "license": "MIT",
       "devDependencies": {
         "@nestjs/common": "^9.0.9",
@@ -34,7 +34,7 @@
       },
       "peerDependencies": {
         "@nestjs/common": "^7.6.0 || ^8.0.0 || ^9.0.0",
-        "@nestjs/swagger": "^4.8.1 || ^5.0.0 || 6.0.0"
+        "@nestjs/swagger": "^4.8.1 || ^5.0.0 || ^6.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nanogiants/nestjs-swagger-api-exception-decorator",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "NestJS Swagger decorator for API exceptions",
   "main": "./dist/index",
   "types": "./dist/index",
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {
     "@nestjs/common": "^7.6.0 || ^8.0.0 || ^9.0.0",
-    "@nestjs/swagger": "^4.8.1 || ^5.0.0 || 6.0.0"
+    "@nestjs/swagger": "^4.8.1 || ^5.0.0 || ^6.0.0"
   },
   "devDependencies": {
     "@nestjs/common": "^9.0.9",


### PR DESCRIPTION
To solve issue with 
```
 Could not resolve dependency:
npm ERR! peer @nestjs/swagger@"^4.8.1 || ^5.0.0 || 6.0.0" from @nanogiants/nestjs-swagger-api-exception-decorator@1.6.3
npm ERR! node_modules/@nanogiants/nestjs-swagger-api-exception-decorator
npm ERR!   @nanogiants/nestjs-swagger-api-exception-decorator@"^1.6.3" from the root project
```

Its pretty much related to issue I opened earlier
https://github.com/nanogiants/nestjs-swagger-api-exception-decorator/issues/44

Just to add a bit more context, it works when blocking my repository on
Package            Current  Wanted 
@nestjs/swagger      6.0.0   6.1.2

But you end up with 
```
npm WARN ERESOLVE overriding peer dependency
npm WARN While resolving: @nestjs/mapped-types@1.0.1
npm WARN Found: @nestjs/common@9.1.1
npm WARN node_modules/@nestjs/common
npm WARN   peer @nestjs/common@"^7.6.0 || ^8.0.0 || ^9.0.0" from @nanogiants/nestjs-swagger-api-exception-decorator@1.6.3
npm WARN   node_modules/@nanogiants/nestjs-swagger-api-exception-decorator
npm WARN     @nanogiants/nestjs-swagger-api-exception-decorator@"^1.6.3" from the root project
npm WARN   12 more (@nestjs/config, @nestjs/core, @nestjs/jwt, ...)

```
Upon node install of new packages