### PR TITLE
Added support for `@nestjs/swagger@6.0.0`  and above

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {
     "@nestjs/common": "^7.6.0 || ^8.0.0 || ^9.0.0",
-    "@nestjs/swagger": "^4.8.1 || ^5.0.0 || 6.0.0"
+    "@nestjs/swagger": "^4.8.1 || ^5.0.0 || ^6.0.0"
   },
   "devDependencies": {
     "@nestjs/common": "^9.0.9",


### PR DESCRIPTION
Currently, this package strictly requires `nestjs/swagger@6.0.0`