### PR TITLE
feat(deps): Bump @nestjs/* peerDependencies to ^11.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "url": "https://github.com/nanogiants/nestjs-swagger-api-exception-decorator.git"
   },
   "peerDependencies": {
-    "@nestjs/common": "^7.6.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
-    "@nestjs/swagger": "^4.8.1 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+    "@nestjs/common": "^7.6.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+    "@nestjs/swagger": "^4.8.1 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^11.0.0"
   },
   "devDependencies": {
     "@nestjs/common": "^10.4.15",


### PR DESCRIPTION
Package works fine with `@nestjs/common` and `@nestjs/swagger` `^11.0.0`, so I can think we can bump these. I tested on multiple occasions, e.g. here:

https://github.com/spuxx-dev/jslibs/blob/main/apps/nest/package.json#L16